### PR TITLE
add show_equivalent option

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -82,6 +82,7 @@ export class Interpreter implements StmtVisitor<void> {
     private rename_free_vars: boolean;
     private logger: Logger;
     private resolver: BindingResolver;
+    private show_equivalence: boolean;
 
     constructor(options?: InterpreterOptions) {
         this.setOptions(options);
@@ -93,6 +94,12 @@ export class Interpreter implements StmtVisitor<void> {
                 ? options.rename_free_vars
                 : this.rename_free_vars
             : this.rename_free_vars || false;
+
+        this.show_equivalence = options
+          ? options.show_equivalent !== undefined
+            ? options.show_equivalent
+            : this.show_equivalence
+          : this.show_equivalence || true;
 
         if (!this.logger) {
             this.logger = new Logger({
@@ -160,7 +167,7 @@ export class Interpreter implements StmtVisitor<void> {
             if (binding_name) this.logger.log(`>>> ${binding_name} = ${stringify(reduct)}`);
             else this.logger.log(`>>> ${stringify(reduct)}`);
             const s_hash: number = structureHash(reduct);
-            if (s_hash in this.structure_hashes)
+            if (this.show_equivalence && s_hash in this.structure_hashes)
                 this.logger.log(`    ↳ equivalent to: ${this.structure_hashes[s_hash].join(", ")}`);
             this.logger.vlog();
             return reduct;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface InterpreterOptions {
     verbosity?: Verbosity;
     output_stream?: Writable;
     rename_free_vars?: boolean;
+    show_equivalent?: boolean;
 }
 
 export interface LoggerOptions {

--- a/tests/interpreter.test.ts
+++ b/tests/interpreter.test.ts
@@ -14,5 +14,8 @@ describe("Interpreter tests", () => {
         int.evaluate("x");
         int.setOptions({ verbosity: Verbosity.LOW, rename_free_vars: true });
         int.evaluate("x");
+        int.evaluate("true") // expects equivalent to true
+        int.setOptions({ verbosity: Verbosity.NONE, show_equivalent: false })
+        int.evaluate("true") // expects no equivalent line
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^2.11.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -616,6 +621,13 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-package@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-package/-/find-package-1.0.0.tgz#d7738da67e3c5f055c24d3e19aa1aeed063c3e83"
+  integrity sha1-13ONpn48XwVcJNPhmqGu7QY8PoM=
+  dependencies:
+    parents "^1.0.1"
+
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -644,6 +656,15 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+genversion@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/genversion/-/genversion-2.3.1.tgz#3246e4fcf374f6476e063804dbf8a82e2cac5429"
+  integrity sha512-YzfTe91VSZYdLnf8av/aet0uuljOzK99203vineGqhmzdjqRezcSleGma+njVp8RDxzHQY6Pg4MImwchcon3ig==
+  dependencies:
+    commander "^2.11.0"
+    find-package "^1.0.0"
+    mkdirp "^0.5.1"
 
 get-caller-file@^2.0.1:
   version "2.0.5"
@@ -1217,6 +1238,13 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
+parents@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
+  integrity sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=
+  dependencies:
+    path-platform "~0.11.15"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -1226,6 +1254,11 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-platform@~0.11.15:
+  version "0.11.15"
+  resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
+  integrity sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=
 
 pathval@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
I added show_equivalent option which will be normally set to true, and this means that the program will work as it would normally. However, adding option show_equivalent to false will result in the logger not printing the "equivalent to [sth]" that is defined in your binding section. 

I would say that this might be more api friendly. Moreover, I think if the function evaluate in interpret.ts file could return a promise, it would be even better. Will look into this later.

Also, test file added according to my change. It should work just fine!